### PR TITLE
Feature/News

### DIFF
--- a/articles/cms_toolbars.py
+++ b/articles/cms_toolbars.py
@@ -64,7 +64,7 @@ class ArticleToolbar(CMSToolbar):
 
         if user and view_name:
             # If we're on an Article detail page, then get the article
-            if view_name == 'article_detail':
+            if view_name == 'articles:article_detail':
                 kwargs = self.request.resolver_match.kwargs
                 article = Article.objects.translated(
                     slug=kwargs['slug']

--- a/articles/cms_toolbars.py
+++ b/articles/cms_toolbars.py
@@ -64,7 +64,7 @@ class ArticleToolbar(CMSToolbar):
 
         if user and view_name:
             # If we're on an Article detail page, then get the article
-            if view_name == 'articles:article_detail':
+            if view_name.endswith('article_detail'):
                 kwargs = self.request.resolver_match.kwargs
                 article = Article.objects.translated(
                     slug=kwargs['slug']

--- a/articles/managers.py
+++ b/articles/managers.py
@@ -14,7 +14,6 @@ from django.db import models
 from django.utils.timezone import now
 
 from aldryn_apphooks_config.managers.base import ManagerMixin, QuerySetMixin
-from aldryn_people.models import Person
 from parler.managers import TranslatableManager, TranslatableQuerySet
 from taggit.models import Tag, TaggedItem
 
@@ -30,7 +29,7 @@ class ArticleQuerySet(QuerySetMixin, TranslatableQuerySet):
         """
         Returns articles that are not drafts
         """
-        return self.exclude(is_draft=False)
+        return self.filter(is_draft=False)
 
     def published(self):
         """

--- a/articles/managers.py
+++ b/articles/managers.py
@@ -30,7 +30,7 @@ class ArticleQuerySet(QuerySetMixin, TranslatableQuerySet):
         """
         Returns articles that are not drafts
         """
-        return self.filter(is_draft=False)
+        return self.exclude(is_draft=False)
 
     def published(self):
         """

--- a/articles/models.py
+++ b/articles/models.py
@@ -264,10 +264,10 @@ class Article(TranslationHelperMixin,
         Copy all the plugins to a new article.
         :param target: The page where the new content should be stored
         """
-        # TODO: Make this into a "graceful" copy instead of deleting and overwriting
-        # copy the placeholders (and plugins on those placeholders!)
+        # TODO: Make this into a "graceful" copy instead of deleting and
+        # overwriting copy the placeholders
+        # (and plugins on those placeholders!)
 
-        plugin_pool.set_plugin_meta()
         plugins = CMSPlugin.objects.filter(
             placeholder=target.content,
             language=language

--- a/articles/models.py
+++ b/articles/models.py
@@ -75,7 +75,11 @@ class Article(TranslationHelperMixin,
         related_name='articles',
     )
     translations = TranslatedFields(
-        title=models.CharField(_('title'), max_length=234),
+        title=models.CharField(
+            _('title'),
+            max_length=234,
+            unique=True,
+        ),
         slug=models.SlugField(
             verbose_name=_('slug'),
             max_length=255,

--- a/articles/static/articles/js/editor.js
+++ b/articles/static/articles/js/editor.js
@@ -473,7 +473,7 @@
     return Editor;
   })();
 
-  $(function () {
+  function setup() {
     $('.editor-zone .cms-plugin').on('dblclick', function (e) {
       var data = $(this).data('cms')[0];
 
@@ -483,7 +483,16 @@
 
         new Editor(data).open();
       }
-    })
+    });
+  }
+
+
+  $(function () {
+    setup();
+  });
+
+  $(window).on('cms-content-refresh', function () {
+    setup();
   });
 
 })(CMS.$);

--- a/articles/static/articles/js/quick-access.js
+++ b/articles/static/articles/js/quick-access.js
@@ -198,11 +198,11 @@
   }
 
   $(function () {
-    setup()
+    //setup();
   });
 
   $(window).on('cms-content-refresh', function () {
-    setup();
+    //setup();
   });
 
 

--- a/articles/static/articles/js/quick-access.js
+++ b/articles/static/articles/js/quick-access.js
@@ -158,7 +158,7 @@
     });
   };
 
-  $(function () {
+  function setup() {
     $('.editor-zone').quickAccess({
       onToolClick: function (pluginData, parentPlugin, position) {
         var url;
@@ -195,7 +195,16 @@
         });
       }
     });
+  }
+
+  $(function () {
+    setup()
   });
+
+  $(window).on('cms-content-refresh', function () {
+    setup();
+  });
+
 
 })(CMS.$);
 

--- a/articles/views.py
+++ b/articles/views.py
@@ -51,6 +51,8 @@ class PreviewModeMixin(EditModeMixin):
         if self.edit_mode and user_can_edit:
             qs = qs.draft()
         else:
+            # if the user can edit, but there is no published version,
+            # then show the draft as a preview
             if user_can_edit and not qs.not_draft().exists():
                 qs = qs.draft()
             else:

--- a/articles/views.py
+++ b/articles/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """ Views for the articles application. """
 # standard library
+import json
 
 # django
 from django.shortcuts import get_object_or_404
@@ -120,6 +121,11 @@ class ArticleDetailView(PreviewModeMixin, TranslatableSlugMixin,
     """
     model = Article
     template_name = 'articles/article_detail.pug'
+
+    def get_context_data(self, **kwargs):
+        context = super(ArticleDetailView, self).get_context_data(**kwargs)
+        context['edit_mode'] = json.dumps(self.edit_mode)
+        return context
 
 
 def add_text_plugin_to_article(article_id, language='es', content='Doble click para editar el texto',

--- a/articles/views.py
+++ b/articles/views.py
@@ -58,12 +58,12 @@ class PreviewModeMixin(EditModeMixin):
 
                 if hasattr(self, 'slug_url_kwarg'):
                     slug = self.kwargs.get(self.slug_url_kwarg)
-                    if not qs.not_draft().translated(slug=slug).exists():
+                    if not qs.published().translated(slug=slug).exists():
                         not_draft_exists = False
                         qs = qs.draft()
 
                 if not_draft_exists:
-                    qs = qs.not_draft()
+                    qs = qs.published()
 
         language = translation.get_language()
         qs = qs.active_translations(language)

--- a/base/templates/base.pug
+++ b/base/templates/base.pug
@@ -229,6 +229,7 @@ html(lang="{{ LANGUAGE_CODE }}").a11y-font-0
           csrftoken: '{{csrf_token}}',
           {% get_current_language as current_language %}
           currentLanguage: '{{ current_language }}',
+          editMode: {{ edit_mode|default:'false' }},
           {% if article %}
           placeholderId: {{article.content_id}},
           {% endif %}

--- a/project/settings.py
+++ b/project/settings.py
@@ -603,3 +603,7 @@ GOBCL_EMAIL_ACCESS_URL = get_local_value('GOBCL_EMAIL_ACCESS_URL', '')
 GOBCL_EMAIL_CLIENT_ID = get_local_value('GOBCL_EMAIL_CLIENT_ID', '')
 GOBCL_EMAIL_CLIENT_SECRET = get_local_value('GOBCL_EMAIL_CLIENT_SECRET', '')
 GOBCL_EMAIL_TOKEN_APP = get_local_value('GOBCL_EMAIL_TOKEN_APP', '')
+
+CKEDITOR_SETTINGS = {
+    'removeButtons': 'cmsplugins'
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.11
 Fabric3==1.13.1.post1
 aldryn-search==0.4.1
 boto3==1.4.7
-git+https://github.com/magnet-cl/django-cms.git@release/3.4.x
+django-cms==3.5.2
 django-compressor-autoprefixer==0.1.0
 django-compressor==2.2
 django-debug-toolbar==1.8
@@ -24,7 +24,7 @@ djangocms-file==2.0.2
 djangocms-googlemap==1.1.1
 djangocms-link==2.1.2
 djangocms-picture==2.0.6
-djangocms-snippet==1.9.2
+djangocms-snippet==2.0.0
 djangocms-style==2.0.2
 djangocms-text-ckeditor==3.5.1
 djangocms-video==2.0.4

--- a/searches/context_processors.py
+++ b/searches/context_processors.py
@@ -5,14 +5,14 @@ import copy
 from django.core.cache import caches
 
 # models
-from aldryn_newsblog.models import Article
+from articles.models import Article
 
 
 def featured_news():
     """
     Returns a list of the 3 featured articles.
     """
-    articles = Article.objects.filter(
+    articles = Article.objects.translated(
         is_featured=True
     ).published().prefetch_related(
         'categories'


### PR DESCRIPTION
- chore: update to django cms 3.5.2
- feat: remove cms plugins from ckeditor.

before pull run this: 
```
python manage.py migrate  # to ensure that your database is up-to-date with migrations
python manage.py cms fix-tree
```

after pull run this: 

```
./quickstart.sh -p
python manage.py migrate
```


[django-cms upgrade](http://docs.django-cms.org/en/develop/upgrade/3.5.html#how-to-upgrade-to-3-5)