### PR TITLE
Fix/elasticsearch concurrency

### DIFF
--- a/base/models.py
+++ b/base/models.py
@@ -158,10 +158,10 @@ class BaseModel(models.Model):
         """
         languages = ('es', 'en', 'ALL')
         for language in languages:
-            doc = self.get_elasticsearch_doc(language_code=language)
-
-            if doc is not None:
-                doc.delete()
+            SearchIndex().delete(
+                id=self.get_elasticsearch_id(language_code=language),
+                ignore=404
+            )
 
     def reindex_in_elasticsearch(self):
         """

--- a/campaigns/managers.py
+++ b/campaigns/managers.py
@@ -23,11 +23,6 @@ class CampaignManager(TranslatableManager):
             using=self._db
         ).select_related('image')
 
-        for obj in queryset:
-            obj.deindex_in_elasticsearch()
-            if obj.is_active():
-                obj.index_in_elasticsearch(1)
-
         return queryset
 
     def active(self):


### PR DESCRIPTION
- Removed reindexing of campaigns when getting the campaigns queryset

- Document deletion in elasticsearch is now made atomically, solving concurrency problems