### PR TITLE
Removed reference to quick-access.js due to not being used

### DIFF
--- a/base/templates/base.pug
+++ b/base/templates/base.pug
@@ -248,7 +248,6 @@ html(lang="{{ LANGUAGE_CODE }}").a11y-font-0
     script(src="{% static 'js/application.js' %}")
     script(src="{% static 'cms_plugins/gallery/js/gallery.js' %}")
     script(src="{% static 'articles/js/editor.js' %}")
-    script(src="{% static 'articles/js/quick-access.js' %}")
     {% endcompress %}
 
     block javascripts


### PR DESCRIPTION
Home (unknown user), CMS var does not exist. quick-access.js uses this var, but this js is not being used. The solution was removing quick-access.js from references. 